### PR TITLE
Change alpine to a set version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM alpine:3.11
 USER root
 
 RUN apk add curl bash expect python2


### PR DESCRIPTION
Seems like base alpine version made changes that breaks if you don't explicitly run python 2 command. 

Setting the version of alpine to an earlier version seem to work. 